### PR TITLE
fix: restrict GitHub App token to managed repos only

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -37,6 +37,11 @@ jobs:
           app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: |
+            repo-ops
+            infra
+            kradio
+            ansible-role-docker-compose-homestack
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Summary

- Adds `repositories:` to `actions/create-github-app-token` in `renovate.yml`, scoping the token to the 4 repos Renovate manages instead of all repos in the owner's app installation
- Fixes zizmor/github-app code scanning alerts #68 and #70 (both `error` severity)

## Test plan

- [x] Renovate run completes successfully after merge (token still covers all 4 repos in `.github/config.json`)
- [x] `gh api repos/micxer/repo-ops/code-scanning/alerts?state=open` returns empty after zizmor rescans