### PR TITLE
fix: grant GitHub App token issues:write for Dependency Dashboard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,6 +44,7 @@ jobs:
             ansible-role-docker-compose-homestack
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Summary

- Renovate was logging `integration-unauthorized` on `ansible-role-docker-compose-homestack` when trying to create/update the Dependency Dashboard issue
- Root cause: `create-github-app-token` step was missing `permission-issues: write`
- Adds the missing permission

## Test plan

- [x] Trigger Renovate workflow manually after merge
- [x] Verify no `Could not ensure issue` / `integration-unauthorized` warning for `ansible-role-docker-compose-homestack`