### PR TITLE
fix: grant GitHub App token vulnerability-alerts:read

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -45,6 +45,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-vulnerability-alerts: read
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Summary

- Renovate logs `Cannot access vulnerability alerts` on repos due to missing permission
- Adds `permission-vulnerability-alerts: read` to the `create-github-app-token` step

## Prerequisites

The GitHub App itself must have `Vulnerability alerts: Read` enabled under its repository permissions — otherwise this token-level grant has no effect. Check at `github.com/settings/apps/<app-name>/permissions`.

## Test plan

- [ ] Enable `Vulnerability alerts: Read` on the GitHub App if not already set
- [ ] Trigger Renovate workflow manually after merge
- [ ] Verify no `Cannot access vulnerability alerts` warning